### PR TITLE
Adopt standard PEAR/Zend style PHP coding & naming convention

### DIFF
--- a/Yahoo/Messenger/Engine.php
+++ b/Yahoo/Messenger/Engine.php
@@ -476,11 +476,6 @@ class Yahoo_Messenger_Engine
 	 */
 	private function curl($url, $method = 'get', $header = null, $postdata = null, $timeout = 60)
 	{
-		// debugging aid
-//		echo ">> $method $url\n";
-//		echo "Headers: $header\n";
-//		echo "POST data: $postdata\n";
-
 		$s = curl_init();
 
 		curl_setopt($s,CURLOPT_URL, $url);
@@ -522,9 +517,6 @@ class Yahoo_Messenger_Engine
 		
 		curl_close($s);
 		
-		// debugging aid
-//		echo "<< $html\n";
-
 		return $html;
 	}
 

--- a/Yahoo/Messenger/Engine.php
+++ b/Yahoo/Messenger/Engine.php
@@ -66,7 +66,7 @@ class Yahoo_Messenger_Engine
 	public function fetchRequestToken()
 	{	
 		//prepare url
-		$url = $this::URL_OAUTH_DIRECT;
+		$url = self::URL_OAUTH_DIRECT;
 		$url .= '?login='. $this->_config['username'];
 		$url .= '&passwd='. $this->_config['password'];
 		$url .= '&oauth_consumer_key='. $this->_config['consumer_key'];		
@@ -82,7 +82,7 @@ class Yahoo_Messenger_Engine
 	public function fetchAccessToken()
 	{
 		//prepare url
-		$url = $this::URL_OAUTH_ACCESS_TOKEN;
+		$url = self::URL_OAUTH_ACCESS_TOKEN;
 		$url .= '?oauth_consumer_key='. $this->_config['consumer_key'];		
 		$url .= '&oauth_nonce='. uniqid(rand());
 		$url .= '&oauth_signature='. $this->_config['secret_key']. '%26';
@@ -114,7 +114,7 @@ class Yahoo_Messenger_Engine
 	public function fetchCrumb()
 	{
 		//prepare url
-		$url = $this::URL_YM_SESSION;
+		$url = self::URL_YM_SESSION;
 		$url .= '?oauth_consumer_key='. $this->_config['consumer_key'];		
 		$url .= '&oauth_nonce='. uniqid(rand());
 		$url .= '&oauth_signature='. $this->_config['secret_key']. '%26'. $this->_token['access']['oauth_token_secret'];
@@ -138,7 +138,7 @@ class Yahoo_Messenger_Engine
 	public function signon($status = '', $state = 0)
 	{
 		//prepare url
-		$url = $this::URL_YM_SESSION;
+		$url = self::URL_YM_SESSION;
 		$url .= '?oauth_consumer_key='. $this->_config['consumer_key'];		
 		$url .= '&oauth_nonce='. uniqid(rand());
 		$url .= '&oauth_signature='. $this->_config['secret_key']. '%26'. $this->_token['access']['oauth_token_secret'];
@@ -173,7 +173,7 @@ class Yahoo_Messenger_Engine
 	public function signoff()
 	{
 		//prepare url
-		$url = $this::URL_YM_SESSION;
+		$url = self::URL_YM_SESSION;
 		$url .= '?oauth_consumer_key='. $this->_config['consumer_key'];		
 		$url .= '&oauth_nonce='. uniqid(rand());
 		$url .= '&oauth_signature='. $this->_config['secret_key']. '%26'. $this->_token['access']['oauth_token_secret'];
@@ -193,7 +193,7 @@ class Yahoo_Messenger_Engine
 	public function changePresence($status = '', $state = 0)
 	{
 		//prepare url
-		$url = $this::URL_YM_PRESENCE;
+		$url = self::URL_YM_PRESENCE;
 		$url .= '?oauth_consumer_key='. $this->_config['consumer_key'];		
 		$url .= '&oauth_nonce='. uniqid(rand());
 		$url .= '&oauth_signature='. $this->_config['secret_key']. '%26'. $this->_token['access']['oauth_token_secret'];
@@ -214,7 +214,7 @@ class Yahoo_Messenger_Engine
 	public function sendMessage($user, $message)
 	{
 		//prepare url
-		$url = $this::URL_YM_MESSAGE;
+		$url = self::URL_YM_MESSAGE;
 		$url .= '?oauth_consumer_key='. $this->_config['consumer_key'];		
 		$url .= '&oauth_nonce='. uniqid(rand());
 		$url .= '&oauth_signature='. $this->_config['secret_key']. '%26'. $this->_token['access']['oauth_token_secret'];
@@ -237,7 +237,7 @@ class Yahoo_Messenger_Engine
 	public function fetchContactList()
 	{
 		//prepare url
-		$url = $this::URL_YM_CONTACT;
+		$url = self::URL_YM_CONTACT;
 		$url .= '?oauth_consumer_key='. $this->_config['consumer_key'];		
 		$url .= '&oauth_nonce='. uniqid(rand());
 		$url .= '&oauth_signature='. $this->_config['secret_key']. '%26'. $this->_token['access']['oauth_token_secret'];
@@ -263,7 +263,7 @@ class Yahoo_Messenger_Engine
 	public function addContact($user, $group = 'Friends', $message = '')
 	{
 		//prepare url
-		$url = $this::URL_YM_GROUP;
+		$url = self::URL_YM_GROUP;
 		$url .= '?oauth_consumer_key='. $this->_config['consumer_key'];		
 		$url .= '&oauth_nonce='. uniqid(rand());
 		$url .= '&oauth_signature='. $this->_config['secret_key']. '%26'. $this->_token['access']['oauth_token_secret'];
@@ -286,7 +286,7 @@ class Yahoo_Messenger_Engine
 	public function deleteContact($user, $group = 'Friends')
 	{
 		//prepare url
-		$url = $this::URL_YM_GROUP;
+		$url = self::URL_YM_GROUP;
 		$url .= '?oauth_consumer_key='. $this->_config['consumer_key'];		
 		$url .= '&oauth_nonce='. uniqid(rand());
 		$url .= '&oauth_signature='. $this->_config['secret_key']. '%26'. $this->_token['access']['oauth_token_secret'];
@@ -319,7 +319,7 @@ class Yahoo_Messenger_Engine
 		}
 		
 		//prepare url
-		$url = $this::URL_YM_BUDDYREQUEST;
+		$url = self::URL_YM_BUDDYREQUEST;
 		$url .= '?oauth_consumer_key='. $this->_config['consumer_key'];		
 		$url .= '&oauth_nonce='. uniqid(rand());
 		$url .= '&oauth_signature='. $this->_config['secret_key']. '%26'. $this->_token['access']['oauth_token_secret'];
@@ -362,7 +362,7 @@ class Yahoo_Messenger_Engine
 	public function fetchNotification($seq = 0)
 	{		
 		//prepare url
-		$url = $this::URL_YM_NOTIFICATION;
+		$url = self::URL_YM_NOTIFICATION;
 		$url .= '?oauth_consumer_key='. $this->_config['consumer_key'];		
 		$url .= '&oauth_nonce='. uniqid(rand());
 		$url .= '&oauth_signature='. $this->_config['secret_key']. '%26'. $this->_token['access']['oauth_token_secret'];
@@ -396,7 +396,7 @@ class Yahoo_Messenger_Engine
 	public function fetchLongNotification($seq = 0)
 	{		
 		//prepare url
-		$url = $this::URL_YM_NOTIFICATION_LONG;
+		$url = self::URL_YM_NOTIFICATION_LONG;
 		$url .= '?oauth_consumer_key='. $this->_config['consumer_key'];		
 		$url .= '&oauth_nonce='. uniqid(rand());
 		$url .= '&oauth_signature='. $this->_config['secret_key']. '%26'. $this->_token['access']['oauth_token_secret'];
@@ -462,7 +462,7 @@ class Yahoo_Messenger_Engine
 	
 	/**
 	 * Sets the request token manually.
-	 * @param string $requestToken
+	 * @param string $requestToken Request token.
 	 */
 	public function setRequestToken($requestToken) {
 		if (stripos($requestToken, 'RequestToken') !== false)
@@ -470,6 +470,26 @@ class Yahoo_Messenger_Engine
 		$this->_token['request'] = $requestToken;
 	}
 	
+	public function getAccessToken() {
+		return $this->_token['access'];
+	}
+	
+	/**
+	 * Sets the access token manually.
+	 * @param string $accessToken Access token.
+	 */
+	public function setAccessToken($accessToken) {
+		$this->_token['access'] = $accessToken;
+	}
+	
+	public function getState() {
+		return array('token' => $this->_token, 'ym' => $this->_ym);
+	}
+	
+	public function setState($state) {
+		$this->_token = $state['token'];
+		$this->_ym = $state['ym'];
+	}
 	
 	/*
 	 * fetch url using curl

--- a/Yahoo/Messenger/Engine.php
+++ b/Yahoo/Messenger/Engine.php
@@ -476,9 +476,10 @@ class Yahoo_Messenger_Engine
 	 */
 	private function curl($url, $method = 'get', $header = null, $postdata = null, $timeout = 60)
 	{
-		echo ">> $method $url\n";
-		echo "Headers: $header\n";
-		echo "POST data: $postdata\n";
+		// debugging aid
+//		echo ">> $method $url\n";
+//		echo "Headers: $header\n";
+//		echo "POST data: $postdata\n";
 
 		$s = curl_init();
 
@@ -520,6 +521,9 @@ class Yahoo_Messenger_Engine
 		$status = curl_getinfo($s, CURLINFO_HTTP_CODE);
 		
 		curl_close($s);
+		
+		// debugging aid
+//		echo "<< $html\n";
 
 		return $html;
 	}

--- a/Yahoo/Messenger/Engine.php
+++ b/Yahoo/Messenger/Engine.php
@@ -27,7 +27,7 @@
  *
 */
  
-class JYMEngine
+class Yahoo_Messenger_Engine
 {
 	const URL_OAUTH_DIRECT = 'https://login.yahoo.com/WSLogin/V1/get_auth_token';
 	const URL_OAUTH_ACCESS_TOKEN = 'https://api.login.yahoo.com/oauth/v2/get_token';

--- a/client.php
+++ b/client.php
@@ -31,9 +31,9 @@ define('PASSWORD', '');
 define('CONSUMER_KEY', '');
 define('SECRET_KEY', '');
 
-include_once 'jymengine.class.php';
+require_once 'Yahoo/Messenger/Engine.php';
 
-$engine = new JYMEngine(CONSUMER_KEY, SECRET_KEY, USERNAME, PASSWORD);
+$engine = new Yahoo_Messenger_Engine(CONSUMER_KEY, SECRET_KEY, USERNAME, PASSWORD);
 $engine->debug = false;
 
 if ($engine->debug) echo '> Fetching request token'. PHP_EOL;

--- a/client.php
+++ b/client.php
@@ -37,10 +37,10 @@ $engine = new JYMEngine(CONSUMER_KEY, SECRET_KEY, USERNAME, PASSWORD);
 $engine->debug = false;
 
 if ($engine->debug) echo '> Fetching request token'. PHP_EOL;
-if (!$engine->fetch_request_token()) die('Fetching request token failed');
+if (!$engine->fetchRequestToken()) die('Fetching request token failed');
 
 if ($engine->debug) echo '> Fetching access token'. PHP_EOL;
-if (!$engine->fetch_access_token()) die('Fetching access token failed');
+if (!$engine->fetchAccessToken()) die('Fetching access token failed');
 
 if ($engine->debug) echo '> Signon as: '. USERNAME. PHP_EOL;
 if (!$engine->signon('I am login from PHP code')) die('Signon failed');
@@ -48,15 +48,15 @@ if (!$engine->signon('I am login from PHP code')) die('Signon failed');
 $seq = -1;
 while (true)
 {
-	$resp = $engine->fetch_long_notification($seq+1);
+	$resp = $engine->fetchLongNotification($seq+1);
 	if (isset($resp))
 	{	
 		if ($resp === false) 
 		{		
-			if ($engine->get_error() != -10)
+			if ($engine->getError() != -10)
 			{
 				if ($engine->debug) echo '> Fetching access token'. PHP_EOL;
-				if (!$engine->fetch_access_token()) die('Fetching access token failed');				
+				if (!$engine->fetchAccessToken()) die('Fetching access token failed');				
 				
 				if ($engine->debug) echo '> Signon as: '. USERNAME. PHP_EOL;
 				if (!$engine->signon(date('H:i:s'))) die('Signon failed');
@@ -133,7 +133,7 @@ while (true)
 					}	
 					else if ($words[0] == 'status')
 					{
-						$engine->change_presence(str_replace('status ', '', strtolower($val['msg'])));
+						$engine->changePresence(str_replace('status ', '', strtolower($val['msg'])));
 						$out = 'My status is changed';
 					}	
 					else
@@ -145,17 +145,17 @@ while (true)
 					if ($engine->debug) echo '> Sending reply message '. PHP_EOL;
 					if ($engine->debug) echo '    '. $out. PHP_EOL;	
 					if ($engine->debug) echo '----------'. PHP_EOL;
-					$engine->send_message($val['sender'], json_encode($out));
+					$engine->sendMessage($val['sender'], json_encode($out));
 				}
 				
 				else if ($key == 'buddyAuthorize') //incoming contact request
 				{
 					if ($engine->debug) echo PHP_EOL. 'Accept buddy request from: '. $val['sender']. PHP_EOL;					
 					if ($engine->debug) echo '----------'. PHP_EOL;	
-					if (!$engine->response_contact($val['sender'], true, 'Welcome to my list'))
+					if (!$engine->responseContact($val['sender'], true, 'Welcome to my list'))
 					{
-						$engine->delete_contact($val['sender']);
-						$engine->response_contact($val['sender'], true, 'Welcome to my list');
+						$engine->deleteContact($val['sender']);
+						$engine->responseContact($val['sender'], true, 'Welcome to my list');
 					}
 				}
 		}

--- a/jymengine.class.php
+++ b/jymengine.class.php
@@ -79,16 +79,6 @@ class JYMEngine
 		return true;
 	}
 	
-	/**
-	 * Sets the request token manually.
-	 * @param string $requestToken
-	 */
-	public function setRequestToken($requestToken) {
-		if (stripos($requestToken, 'RequestToken') !== false)
-			$requestToken = trim(str_replace('RequestToken=', '', $requestToken));
-		$this->_token['request'] = $requestToken;
-	}
-	
 	public function fetch_access_token()
 	{
 		//prepare url
@@ -470,7 +460,15 @@ class JYMEngine
 		return $js['responses'];
 	}
 	
-	
+	/**
+	 * Sets the request token manually.
+	 * @param string $requestToken
+	 */
+	public function setRequestToken($requestToken) {
+		if (stripos($requestToken, 'RequestToken') !== false)
+			$requestToken = trim(str_replace('RequestToken=', '', $requestToken));
+		$this->_token['request'] = $requestToken;
+	}
 	
 	
 	/*

--- a/jymengine.class.php
+++ b/jymengine.class.php
@@ -79,6 +79,16 @@ class JYMEngine
 		return true;
 	}
 	
+	/**
+	 * Sets the request token manually.
+	 * @param string $requestToken
+	 */
+	public function setRequestToken($requestToken) {
+		if (stripos($requestToken, 'RequestToken') !== false)
+			$requestToken = trim(str_replace('RequestToken=', '', $requestToken));
+		$this->_token['request'] = $requestToken;
+	}
+	
 	public function fetch_access_token()
 	{
 		//prepare url
@@ -468,6 +478,10 @@ class JYMEngine
 	 */
 	private function curl($url, $method = 'get', $header = null, $postdata = null, $timeout = 60)
 	{
+		echo ">> $method $url\n";
+		echo "Headers: $header\n";
+		echo "POST data: $postdata\n";
+
 		$s = curl_init();
 
 		curl_setopt($s,CURLOPT_URL, $url);

--- a/jymengine.class.php
+++ b/jymengine.class.php
@@ -63,7 +63,7 @@ class JYMEngine
 		$this->_error = null;
 	}
 	
-	public function fetch_request_token()
+	public function fetchRequestToken()
 	{	
 		//prepare url
 		$url = $this::URL_OAUTH_DIRECT;
@@ -79,7 +79,7 @@ class JYMEngine
 		return true;
 	}
 	
-	public function fetch_access_token()
+	public function fetchAccessToken()
 	{
 		//prepare url
 		$url = $this::URL_OAUTH_ACCESS_TOKEN;
@@ -111,7 +111,7 @@ class JYMEngine
 		return true;	
 	}
 	
-	public function fetch_crumb()
+	public function fetchCrumb()
 	{
 		//prepare url
 		$url = $this::URL_YM_SESSION;
@@ -190,7 +190,7 @@ class JYMEngine
 		return true;
 	}
 	
-	public function change_presence($status = '', $state = 0)
+	public function changePresence($status = '', $state = 0)
 	{
 		//prepare url
 		$url = $this::URL_YM_PRESENCE;
@@ -211,7 +211,7 @@ class JYMEngine
 		return true;
 	}
 
-	public function send_message($user, $message)
+	public function sendMessage($user, $message)
 	{
 		//prepare url
 		$url = $this::URL_YM_MESSAGE;
@@ -234,7 +234,7 @@ class JYMEngine
 		return true;
 	}
 	
-	public function fetch_contact_list()
+	public function fetchContactList()
 	{
 		//prepare url
 		$url = $this::URL_YM_CONTACT;
@@ -260,7 +260,7 @@ class JYMEngine
 		return $js['contacts'];
 	}
 	
-	public function add_contact($user, $group = 'Friends', $message = '')
+	public function addContact($user, $group = 'Friends', $message = '')
 	{
 		//prepare url
 		$url = $this::URL_YM_GROUP;
@@ -283,7 +283,7 @@ class JYMEngine
 		return true;
 	}
 
-	public function delete_contact($user, $group = 'Friends')
+	public function deleteContact($user, $group = 'Friends')
 	{
 		//prepare url
 		$url = $this::URL_YM_GROUP;
@@ -305,7 +305,7 @@ class JYMEngine
 		return true;
 	}
 	
-	public function response_contact($user, $accept = true, $message = '')
+	public function responseContact($user, $accept = true, $message = '')
 	{
 		if ($accept)
 		{
@@ -359,7 +359,7 @@ class JYMEngine
 		return true;
 	}
 	
-	public function fetch_notification($seq = 0)
+	public function fetchNotification($seq = 0)
 	{		
 		//prepare url
 		$url = $this::URL_YM_NOTIFICATION;
@@ -393,7 +393,7 @@ class JYMEngine
 		return $js['responses'];
 	}
 	
-	public function fetch_long_notification($seq = 0)
+	public function fetchLongNotification($seq = 0)
 	{		
 		//prepare url
 		$url = $this::URL_YM_NOTIFICATION_LONG;
@@ -524,7 +524,7 @@ class JYMEngine
 		return $html;
 	}
 
-	public function get_error()
+	public function getError()
 	{
 		return $this->_error;
 	}


### PR DESCRIPTION
Make it easier to be integrated with applications and libraries due to familiar coding conventions.

(also add manual setRequestToken)
